### PR TITLE
Remove close() from sendValue when non-binary data

### DIFF
--- a/dslink.json
+++ b/dslink.json
@@ -1,6 +1,6 @@
 {
   "name": "dslink-dart-rest",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "REST Server DSLink",
   "main": "bin/run.dart",
   "engines": {

--- a/lib/server.dart
+++ b/lib/server.dart
@@ -357,7 +357,6 @@ class Server {
       req.response
         ..write(value)
         ..close();
-      close();
       return;
     }
 


### PR DESCRIPTION
This line causes the link to close the server. Fixes #8 
Also bumped version number to v1.1.1